### PR TITLE
Modification du message d'invitation

### DIFF
--- a/templates/email/invitation.html.twig
+++ b/templates/email/invitation.html.twig
@@ -5,7 +5,7 @@
 
 {% block preheader %}Vous avez été invité(e) à rejoindre
 	{{ invitation.club.name }}
-	sur Tarmac
+	sur sa plateforme TARMAC (TÂches de Réparation et de MAintenance Club).
 {% endblock %}
 
 {% block email_title %}Invitation


### PR DESCRIPTION
2 petites modifications dans le message d'invitation pour mettre en majuscule TARMAC et l'expliciter et informer du process quand on a déjà un compte sur un autre club (je me suis fait piéger 2 fois).