### PR TITLE
Normaliser le sous-domaine des clubs en minuscules

### DIFF
--- a/src/Entity/Club.php
+++ b/src/Entity/Club.php
@@ -93,12 +93,12 @@ class Club
 
     public function getSubdomain(): ?string
     {
-        return $this->subdomain;
+        return $this->subdomain !== null ? mb_strtolower($this->subdomain, 'UTF-8') : null;
     }
 
     public function setSubdomain(string $subdomain): static
     {
-        $this->subdomain = $subdomain;
+        $this->subdomain = mb_strtolower($subdomain, 'UTF-8');
 
         return $this;
     }

--- a/src/Repository/ClubRepository.php
+++ b/src/Repository/ClubRepository.php
@@ -21,7 +21,10 @@ class ClubRepository extends ServiceEntityRepository
      */
     public function findBySubdomain(string $subdomain): ?Club
     {
-        return $this->findOneBy(['subdomain' => $subdomain, 'active' => true]);
+        return $this->findOneBy([
+            'subdomain' => mb_strtolower($subdomain, 'UTF-8'),
+            'active' => true,
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Ticket lié

Cette PR est liée au ticket [#46 — sous-domaine en minuscules](https://github.com/Tilotiti/tarmac/issues/46) et vise à le résoudre.

## Contexte

Le sous-domaine d’un club doit rester en minuscules pour éviter les incohérences (URLs, résolution multi-tenant, contrainte d’unicité).

## Modifications

- **`Club`** : `setSubdomain()` applique `mb_strtolower(..., 'UTF-8')` à la valeur stockée ; `getSubdomain()` renvoie également la valeur en minuscules pour un comportement cohérent même si d’anciennes lignes en base contenaient des majuscules.
- **`ClubRepository::findBySubdomain()`** : le paramètre de recherche est normalisé de la même façon pour rester aligné avec le stockage et l’hôte HTTP.

## Notes

- Aucune migration obligatoire : les prochains enregistrements sont corrects. Une mise à jour SQL optionnelle (`UPDATE club SET subdomain = lower(subdomain)`) peut uniformiser d’anciennes données si nécessaire.