### PR TITLE
Plans club : import XLSX guidé, création sans tâches obligatoires, footer formulaire

### DIFF
--- a/assets/controllers/plan_form_controller.js
+++ b/assets/controllers/plan_form_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
 
         // Count existing tasks on page load
         this.updateTaskCount();
+        this.updatePlaceholder();
     }
 
     updateTaskCount() {
@@ -52,9 +53,6 @@ export default class extends Controller {
 
         // Hide placeholder if exists
         this.updatePlaceholder();
-
-        // Automatically create the first subtask for this new task
-        this.addSubTaskToTask(taskIndex);
     }
 
     addSubTaskToTask(taskIndex) {
@@ -176,13 +174,5 @@ export default class extends Controller {
         }
     }
 
-    scrollToBottom(event) {
-        event.preventDefault();
-
-        window.scrollTo({
-            top: document.documentElement.scrollHeight,
-            behavior: 'smooth',
-        });
-    }
 }
 

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -678,37 +678,6 @@
     }
 }
 
-/* Floating actions for maintenance plan edit form */
-.plan-form-actions {
-    position: fixed;
-    right: 1.25rem;
-    bottom: 1.25rem;
-    z-index: 1030;
-    max-width: calc(100% - 2.5rem);
-}
-
-.plan-form-actions-spacer {
-    height: 6.5rem;
-}
-
-@media (max-width: 575.98px) {
-    .plan-form-actions {
-        left: 0.75rem;
-        right: 0.75rem;
-        bottom: 0.75rem;
-        max-width: none;
-    }
-
-    .plan-form-actions .card-body {
-        display: flex;
-        gap: 0.5rem;
-    }
-
-    .plan-form-actions .btn {
-        flex: 1 1 0;
-    }
-}
-
 /* Tom Select (member / user pickers) — aligné Tabler */
 .member-select.ts-wrapper {
     width: 100%;

--- a/src/Controller/Club/PlanController.php
+++ b/src/Controller/Club/PlanController.php
@@ -3,8 +3,6 @@
 namespace App\Controller\Club;
 
 use App\Entity\Plan;
-use App\Entity\PlanTask;
-use App\Entity\PlanSubTask;
 use App\Form\PlanImportType;
 use App\Form\PlanType;
 use App\Entity\Equipment;
@@ -90,33 +88,13 @@ class PlanController extends ExtendedController
         $plan->setClub($club);
         $plan->setCreatedBy($this->getUser());
 
-        // Force creation of first task and its first subtask
-        if ($plan->getTaskTemplates()->count() === 0) {
-            $firstTask = new PlanTask();
-            $firstTask->setTitle('');
-            $firstTask->setDescription('');
-            $firstTask->setPosition(0);
-            $plan->addTaskTemplate($firstTask);
-
-            $firstSubTask = new PlanSubTask();
-            $firstSubTask->setTitle('');
-            $firstSubTask->setDescription('');
-            $firstSubTask->setDifficulty(3);
-            $firstSubTask->setRequiresInspection(false);
-            $firstSubTask->setPosition(0);
-            $firstTask->addSubTaskTemplate($firstSubTask);
-        }
-
         $form = $this->createForm(PlanType::class, $plan, ['club' => $club]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            // Set positions for task templates
             $position = 0;
             foreach ($plan->getTaskTemplates() as $taskTemplate) {
                 $taskTemplate->setPosition($position++);
-
-                // Set positions for subtask templates
                 $subPosition = 0;
                 foreach ($taskTemplate->getSubTaskTemplates() as $subTaskTemplate) {
                     $subTaskTemplate->setPosition($subPosition++);
@@ -136,6 +114,37 @@ class PlanController extends ExtendedController
             'plan' => $plan,
             'form' => $form,
         ]);
+    }
+
+    #[Route('/import-template', name: 'club_plan_import_template', methods: ['GET'])]
+    #[IsGranted('MANAGE')]
+    public function importTemplate(): Response
+    {
+        $spreadsheet = $this->planSpreadsheetService->generateSpreadsheet(new Plan());
+        $writer = IOFactory::createWriter($spreadsheet, 'Xlsx');
+
+        $tempBase = tempnam(sys_get_temp_dir(), 'plan_template_');
+        if ($tempBase === false) {
+            $this->addFlash('error', 'planExportFailed');
+
+            return $this->redirectToRoute('club_plans');
+        }
+
+        $tempFile = $tempBase . '.xlsx';
+
+        try {
+            $writer->save($tempFile);
+        } catch (\Throwable) {
+            $this->addFlash('error', 'planExportFailed');
+            @unlink($tempBase);
+
+            return $this->redirectToRoute('club_plans');
+        }
+
+        @unlink($tempBase);
+
+        return $this->file($tempFile, 'plan-modele.xlsx', ResponseHeaderBag::DISPOSITION_ATTACHMENT)
+            ->deleteFileAfterSend(true);
     }
 
     #[Route('/{id}', name: 'club_plan_show', requirements: ['id' => '\d+'])]

--- a/src/Form/PlanType.php
+++ b/src/Form/PlanType.php
@@ -10,6 +10,8 @@ use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PlanType extends AbstractType
@@ -34,7 +36,10 @@ class PlanType extends AbstractType
                 'required' => true,
                 'attr' => ['class' => 'form-select'],
             ])
-            ->add('taskTemplates', CollectionType::class, [
+        ;
+
+        if ($options['include_task_templates']) {
+            $builder->add('taskTemplates', CollectionType::class, [
                 'entry_type' => PlanTaskType::class,
                 'entry_options' => [
                     'label' => false,
@@ -45,8 +50,40 @@ class PlanType extends AbstractType
                 'by_reference' => false,
                 'label' => 'tasks',
                 'attr' => ['class' => 'task-templates-collection'],
-            ])
-        ;
+            ]);
+        }
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+            $form = $event->getForm();
+            if (!$form->getConfig()->getOption('include_task_templates')) {
+                return;
+            }
+
+            $data = $event->getData();
+            if (!\is_array($data) || !isset($data['taskTemplates']) || !\is_array($data['taskTemplates'])) {
+                return;
+            }
+
+            $filteredTasks = [];
+            foreach ($data['taskTemplates'] as $taskData) {
+                if (!\is_array($taskData)) {
+                    continue;
+                }
+                if (trim((string) ($taskData['title'] ?? '')) === '') {
+                    continue;
+                }
+                if (isset($taskData['subTaskTemplates']) && \is_array($taskData['subTaskTemplates'])) {
+                    $taskData['subTaskTemplates'] = array_values(array_filter(
+                        $taskData['subTaskTemplates'],
+                        static fn ($subData): bool => \is_array($subData)
+                            && trim((string) ($subData['title'] ?? '')) !== '',
+                    ));
+                }
+                $filteredTasks[] = $taskData;
+            }
+            $data['taskTemplates'] = $filteredTasks;
+            $event->setData($data);
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -54,8 +91,10 @@ class PlanType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Plan::class,
             'club' => null,
+            'include_task_templates' => true,
         ]);
         $resolver->setAllowedTypes('club', ['null', \App\Entity\Club::class]);
+        $resolver->setAllowedTypes('include_task_templates', 'bool');
     }
 }
 

--- a/templates/club/plan/_import_xlsx_panel.html.twig
+++ b/templates/club/plan/_import_xlsx_panel.html.twig
@@ -1,0 +1,37 @@
+{# Expects: importForm (FormView) #}
+<p class="text-secondary small mb-3 mb-md-4">{{ 'planImportModalIntro'|trans }}</p>
+
+<div class="mb-3">
+	<a href="{{ path('club_plan_import_template') }}" class="btn btn-outline-primary w-100 w-sm-auto">
+		<i class="ti ti-download me-2"></i>
+		{{ 'downloadPlanImportTemplate'|trans }}
+	</a>
+	<p class="text-secondary small mt-2 mb-0">{{ 'planImportTemplateHint'|trans }}</p>
+</div>
+
+<div class="alert alert-warning d-flex align-items-start gap-2 mb-3">
+	<i class="ti ti-alert-triangle mt-1 flex-shrink-0"></i>
+	<div>
+		<div class="fw-semibold">{{ 'planImportWarningTitle'|trans }}</div>
+		<div class="small text-muted">{{ 'planImportWarningMessage'|trans }}</div>
+	</div>
+</div>
+
+<div class="mb-3">
+	<div class="fw-semibold small mb-2">{{ 'planImportRulesTitle'|trans }}</div>
+	<ul class="small text-secondary mb-0 ps-3">
+		<li>{{ 'planImportRuleHeaders'|trans }}</li>
+		<li>{{ 'planImportRuleOneRowPerSubtask'|trans }}</li>
+		<li>{{ 'planImportRuleTaskRepeat'|trans }}</li>
+		<li>{{ 'planImportRuleDifficulty'|trans }}</li>
+		<li>{{ 'planImportRuleRequiresInspection'|trans }}</li>
+		<li>{{ 'planImportRuleSpecialisations'|trans }}</li>
+		<li>{{ 'planImportRuleReplaceAll'|trans }}</li>
+	</ul>
+</div>
+
+<div class="mb-3">
+	{{ form_row(importForm.file) }}
+</div>
+
+<p class="text-secondary small mb-0">{{ 'planImportHint'|trans }}</p>

--- a/templates/club/plan/edit.html.twig
+++ b/templates/club/plan/edit.html.twig
@@ -260,22 +260,11 @@
 			</div>
 		</template>
 
-		<div class="plan-form-actions-spacer"></div>
-
-		{# Floating actions bar #}
-		<div class="plan-form-actions">
-			<div class="card shadow-lg">
-				<div class="card-body d-flex align-items-center gap-2">
-					<button type="button" class="btn btn-outline-secondary" data-action="click->plan-form#scrollToBottom">
-						<i class="ti ti-arrow-down me-2"></i>
-						{{ 'goToBottom'|trans }}
-					</button>
-					<button type="submit" class="btn btn-primary">
-						<i class="ti ti-device-floppy me-2"></i>
-						{{ 'save'|trans }}
-					</button>
-				</div>
-			</div>
+		<div class="mt-3 text-center">
+			<button type="submit" class="btn btn-primary btn-lg">
+				<i class="ti ti-device-floppy me-2"></i>
+				{{ 'save'|trans }}
+			</button>
 		</div>
 
 		{% do form.taskTemplates.setRendered %}

--- a/templates/club/plan/new.html.twig
+++ b/templates/club/plan/new.html.twig
@@ -1,5 +1,7 @@
 {% extends 'club/base.html.twig' %}
 
+{% form_theme form 'form/tags.html.twig' %}
+
 {% block page_title %}
 	{{ 'newPlan'|trans }}
 {% endblock %}
@@ -28,12 +30,13 @@
 		{# Tasks section #}
 		<div class="mb-3">
 			<h4>{{ 'tasks'|trans }}</h4>
+			<div class="alert alert-info d-flex align-items-start gap-2 mb-3" role="alert">
+				<i class="ti ti-info-circle mt-1 flex-shrink-0"></i>
+				<div class="small mb-0">{{ 'newPlanTasksOptionalHint'|trans }}</div>
+			</div>
 
-			{# Tasks container #}
-			<div
-				data-plan-form-target="tasksContainer">
-				{# Empty state placeholder #}
-				<div class="text-center py-4 d-none" data-task-placeholder>
+			<div data-plan-form-target="tasksContainer">
+				<div class="text-center py-4" data-task-placeholder style="{% if form.taskTemplates|length > 0 %}display: none;{% else %}display: block;{% endif %}">
 					<p class="text-muted mb-0">{{ 'noTasksInPlan'|trans }}</p>
 				</div>
 
@@ -60,13 +63,10 @@
 								lightboxGroup: 'plan-task-documentation-' ~ loop.index
 							} %}
 
-							{# Subtasks section #}
 							<fieldset class="mt-3 border rounded p-3">
 								<legend class="float-none w-auto px-2 fs-6 mb-3">{{ 'subTasks'|trans }}</legend>
 
-								<div
-									data-subtask-container>
-									{# Empty state placeholder #}
+								<div data-subtask-container>
 									<div class="text-center py-2 d-none" data-subtask-placeholder>
 										<p class="text-muted small mb-0">{{ 'noSubTasks'|trans }}</p>
 									</div>
@@ -91,22 +91,26 @@
 											<div class="mb-2">
 												{{ form_row(subTaskTemplate.description) }}
 											</div>
-											{% include 'component/documentationUploader.html.twig' with {
-												field: subTaskTemplate.documentation,
-												existingUrl: subTaskTemplate.vars.data.documentation ?? null,
-												deletePath: null,
-												lightboxGroup: 'plan-subtask-documentation-' ~ loop.parent.loop.index ~ '-' ~ loop.index
-											} %}
+											{% if subTaskTemplate.specialisations is defined %}
+												<div class="mb-2">
+													{{ form_row(subTaskTemplate.specialisations) }}
+												</div>
+											{% endif %}
 											<div class="mb-2">
 												<div class="form-check form-switch">
 													{{ form_widget(subTaskTemplate.requiresInspection, {'attr': {'class': 'form-check-input'}}) }}
 													{{ form_label(subTaskTemplate.requiresInspection, null, {'label_attr': {'class': 'form-check-label'}}) }}
 												</div>
 											</div>
+											{% include 'component/documentationUploader.html.twig' with {
+												field: subTaskTemplate.documentation,
+												existingUrl: subTaskTemplate.vars.data.documentation ?? null,
+												deletePath: null,
+												lightboxGroup: 'plan-subtask-documentation-' ~ loop.parent.loop.index ~ '-' ~ loop.index
+											} %}
 										</fieldset>
 									{% endfor %}
 
-									{# Add subtask button #}
 									<div class="text-center" data-subtask-add-button>
 										<button type="button" class="btn btn-sm btn-secondary" data-action="click->plan-form#addSubTask" aria-label="{{ 'addSubTask'|trans }}">
 											<i class="ti ti-plus me-2"></i>
@@ -115,7 +119,6 @@
 									</div>
 								</div>
 
-								{# Subtask template (hidden) #}
 								<template data-subtask-template>
 									<fieldset class="form-fieldset mb-3" data-subtask-index="">
 										<legend class="d-flex justify-content-between align-items-center h5 mb-2">
@@ -136,18 +139,23 @@
 										<div class="mb-2">
 											{{ form_row(taskTemplate.subTaskTemplates.vars.prototype.description) }}
 										</div>
-										{% include 'component/documentationUploader.html.twig' with {
-											field: taskTemplate.subTaskTemplates.vars.prototype.documentation,
-											existingUrl: null,
-											deletePath: null,
-											lightboxGroup: 'plan-subtask-documentation-proto'
-										} %}
+										{% if taskTemplate.subTaskTemplates.vars.prototype.specialisations is defined %}
+											<div class="mb-2">
+												{{ form_row(taskTemplate.subTaskTemplates.vars.prototype.specialisations) }}
+											</div>
+										{% endif %}
 										<div class="mb-2">
 											<div class="form-check form-switch">
 												{{ form_widget(taskTemplate.subTaskTemplates.vars.prototype.requiresInspection, {'attr': {'class': 'form-check-input'}}) }}
 												{{ form_label(taskTemplate.subTaskTemplates.vars.prototype.requiresInspection, null, {'label_attr': {'class': 'form-check-label'}}) }}
 											</div>
 										</div>
+										{% include 'component/documentationUploader.html.twig' with {
+											field: taskTemplate.subTaskTemplates.vars.prototype.documentation,
+											existingUrl: null,
+											deletePath: null,
+											lightboxGroup: 'plan-subtask-documentation-proto'
+										} %}
 									</fieldset>
 								</template>
 							</fieldset>
@@ -156,7 +164,6 @@
 				{% endfor %}
 			</div>
 
-			{# Add task button #}
 			<div class="text-center mt-3">
 				<button type="button" class="btn btn-secondary" data-action="click->plan-form#addTask" aria-label="{{ 'addTask'|trans }}">
 					<i class="ti ti-plus me-2"></i>
@@ -165,7 +172,6 @@
 			</div>
 		</div>
 
-		{# Task template (hidden) #}
 		<template data-plan-form-target="taskTemplate">
 			<div class="card mb-3" data-task-index="">
 				<div class="card-header d-flex justify-content-between align-items-center">
@@ -189,18 +195,14 @@
 						lightboxGroup: 'plan-task-documentation-proto'
 					} %}
 
-					{# Subtasks section #}
 					<fieldset class="mt-3 border rounded p-3">
 						<legend class="float-none w-auto px-2 fs-6 mb-3">{{ 'subTasks'|trans }}</legend>
 
-						<div
-							data-subtask-container>
-							{# Empty state placeholder #}
+						<div data-subtask-container>
 							<div class="text-center py-2 d-none" data-subtask-placeholder>
 								<p class="text-muted small mb-0">{{ 'noSubTasks'|trans }}</p>
 							</div>
 
-							{# Add subtask button #}
 							<div class="text-center" data-subtask-add-button>
 								<button type="button" class="btn btn-sm btn-secondary" data-action="click->plan-form#addSubTask" aria-label="{{ 'addSubTask'|trans }}">
 									<i class="ti ti-plus me-2"></i>
@@ -209,7 +211,6 @@
 							</div>
 						</div>
 
-						{# Subtask template (hidden) #}
 						<template data-subtask-template>
 							<fieldset class="form-fieldset mb-3" data-subtask-index="">
 								<legend class="d-flex justify-content-between align-items-center h5 mb-2">
@@ -223,19 +224,30 @@
 									<div class="col-12 col-md-9">
 										{{ form_row(form.taskTemplates.vars.prototype.subTaskTemplates.vars.prototype.title) }}
 									</div>
-									<div class="col-12 col-md-2">
+									<div class="col-12 col-md-3">
 										{{ form_row(form.taskTemplates.vars.prototype.subTaskTemplates.vars.prototype.difficulty) }}
 									</div>
 								</div>
 								<div class="mb-2">
 									{{ form_row(form.taskTemplates.vars.prototype.subTaskTemplates.vars.prototype.description) }}
 								</div>
+								{% if form.taskTemplates.vars.prototype.subTaskTemplates.vars.prototype.specialisations is defined %}
+									<div class="mb-2">
+										{{ form_row(form.taskTemplates.vars.prototype.subTaskTemplates.vars.prototype.specialisations) }}
+									</div>
+								{% endif %}
 								<div class="mb-2">
 									<div class="form-check form-switch">
 										{{ form_widget(form.taskTemplates.vars.prototype.subTaskTemplates.vars.prototype.requiresInspection, {'attr': {'class': 'form-check-input'}}) }}
 										{{ form_label(form.taskTemplates.vars.prototype.subTaskTemplates.vars.prototype.requiresInspection, null, {'label_attr': {'class': 'form-check-label'}}) }}
 									</div>
 								</div>
+								{% include 'component/documentationUploader.html.twig' with {
+									field: form.taskTemplates.vars.prototype.subTaskTemplates.vars.prototype.documentation,
+									existingUrl: null,
+									deletePath: null,
+									lightboxGroup: 'plan-subtask-documentation-proto'
+								} %}
 							</fieldset>
 						</template>
 					</fieldset>
@@ -243,14 +255,11 @@
 			</div>
 		</template>
 
-		{# Save button #}
-		<div class="card mt-3 sticky-bottom-mobile">
-			<div class="card-body d-flex gap-2">
-				<button type="submit" class="btn btn-primary w-100">
+		<div class="mt-3 text-center">
+				<button type="submit" class="btn btn-primary btn-lg">
 					<i class="ti ti-device-floppy me-2"></i>
 					{{ 'save'|trans }}
 				</button>
-			</div>
 		</div>
 
 		{% do form.taskTemplates.setRendered %}

--- a/templates/club/plan/show.html.twig
+++ b/templates/club/plan/show.html.twig
@@ -188,7 +188,7 @@
 			</div>
 			{% if importForm is defined and importForm %}
 				<div class="modal fade" id="plan-import-modal" tabindex="-1" aria-labelledby="plan-import-modal-label" aria-hidden="true">
-					<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+					<div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
 						<div class="modal-content">
 							<div class="modal-header">
 								<h5 class="modal-title" id="plan-import-modal-label">{{ 'importPlanFromXlsx'|trans }}</h5>
@@ -199,17 +199,7 @@
 								attr: {'enctype': 'multipart/form-data'}
 							}) }}
 							<div class="modal-body">
-								<div class="alert alert-warning d-flex align-items-start gap-2">
-									<i class="ti ti-alert-triangle mt-1"></i>
-									<div>
-										<div class="fw-semibold">{{ 'planImportWarningTitle'|trans }}</div>
-										<div class="small text-muted">{{ 'planImportWarningMessage'|trans }}</div>
-									</div>
-								</div>
-								<div class="mb-3">
-									{{ form_row(importForm.file) }}
-								</div>
-								<div class="text-secondary small">{{ 'planImportHint'|trans }}</div>
+								{% include 'club/plan/_import_xlsx_panel.html.twig' %}
 							</div>
 							<div class="modal-footer d-flex flex-column flex-sm-row gap-2">
 								<button type="submit" class="btn btn-primary w-100 w-sm-auto">

--- a/translations/messages+intl-icu.fr.xlf
+++ b/translations/messages+intl-icu.fr.xlf
@@ -593,10 +593,6 @@
         <source>save</source>
         <target>Enregistrer</target>
       </trans-unit>
-      <trans-unit id="94b" resname="goToBottom">
-        <source>goToBottom</source>
-        <target>Aller tout en bas</target>
-      </trans-unit>
       <trans-unit id="94a" resname="create">
         <source>create</source>
         <target>Créer</target>
@@ -924,6 +920,14 @@
         <source>importPlanFromXlsx</source>
         <target>Importer depuis un fichier XLSX</target>
       </trans-unit>
+      <trans-unit id="139cIntro" resname="planImportModalIntro">
+        <source>planImportModalIntro</source>
+        <target>Remplissez le fichier XLSX en respectant les règles ci-dessous, puis sélectionnez-le pour l’importer. Commencez par télécharger le modèle vierge : il contient uniquement la ligne d’en-têtes attendue (ne la modifiez pas).</target>
+      </trans-unit>
+      <trans-unit id="139cTpl" resname="planImportTemplateHint">
+        <source>planImportTemplateHint</source>
+        <target>Ajoutez vos lignes sous les en-têtes : une ligne par sous-tâche (voir les règles ci-dessous).</target>
+      </trans-unit>
       <trans-unit id="139d" resname="planImportWarningTitle">
         <source>planImportWarningTitle</source>
         <target>Attention, cette action est destructive.</target>
@@ -934,7 +938,7 @@
       </trans-unit>
       <trans-unit id="139f" resname="planImportHint">
         <source>planImportHint</source>
-        <target>Utilisez le fichier XLSX exporté ou respectez les colonnes du modèle.</target>
+        <target>Vous pouvez aussi exporter un plan existant pour vous aider. Les en-têtes de colonnes ne doivent pas être modifiés.</target>
       </trans-unit>
       <trans-unit id="139g" resname="planExportFailed">
         <source>planExportFailed</source>
@@ -987,6 +991,46 @@
       <trans-unit id="139s" resname="planImportFile">
         <source>planImportFile</source>
         <target>Fichier XLSX</target>
+      </trans-unit>
+      <trans-unit id="139sDl" resname="downloadPlanImportTemplate">
+        <source>downloadPlanImportTemplate</source>
+        <target>Télécharger le modèle vierge (XLSX)</target>
+      </trans-unit>
+      <trans-unit id="139sRules" resname="planImportRulesTitle">
+        <source>planImportRulesTitle</source>
+        <target>Règles et fonctionnement</target>
+      </trans-unit>
+      <trans-unit id="139sRu1" resname="planImportRuleHeaders">
+        <source>planImportRuleHeaders</source>
+        <target>La première ligne contient les en-têtes obligatoires : elles doivent correspondre exactement au modèle (libellés en français comme dans le fichier téléchargé).</target>
+      </trans-unit>
+      <trans-unit id="139sRu2" resname="planImportRuleOneRowPerSubtask">
+        <source>planImportRuleOneRowPerSubtask</source>
+        <target>Chaque ligne du fichier correspond à une sous-tâche ; les colonnes de la tâche parente sont répétées sur chaque ligne de sous-tâches de cette tâche.</target>
+      </trans-unit>
+      <trans-unit id="139sRu3" resname="planImportRuleTaskRepeat">
+        <source>planImportRuleTaskRepeat</source>
+        <target>Pour regrouper des sous-tâches sous la même tâche, répétez le même titre (et idéalement la même position) de tâche sur les lignes concernées.</target>
+      </trans-unit>
+      <trans-unit id="139sRu4" resname="planImportRuleDifficulty">
+        <source>planImportRuleDifficulty</source>
+        <target>Difficulté : nombre de 1 à 3, ou libellés débutant / expérimenté / expert (ou équivalents anglais).</target>
+      </trans-unit>
+      <trans-unit id="139sRu5" resname="planImportRuleRequiresInspection">
+        <source>planImportRuleRequiresInspection</source>
+        <target>Contrôle requis : 1, oui, true, x, etc. pour activer ; laissez vide pour non.</target>
+      </trans-unit>
+      <trans-unit id="139sRu6" resname="planImportRuleSpecialisations">
+        <source>planImportRuleSpecialisations</source>
+        <target>Spécialisations : noms séparés par des virgules ; elles seront créées pour le club si besoin.</target>
+      </trans-unit>
+      <trans-unit id="139sRu7" resname="planImportRuleReplaceAll">
+        <source>planImportRuleReplaceAll</source>
+        <target>L’import remplace entièrement la liste des tâches et sous-tâches du plan (voir l’avertissement ci-dessus).</target>
+      </trans-unit>
+      <trans-unit id="139sNew" resname="newPlanTasksOptionalHint">
+        <source>newPlanTasksOptionalHint</source>
+        <target>Les tâches et sous-tâches sont facultatives : vous pouvez enregistrer le plan tel quel, ou les renseigner maintenant avec les boutons ci-dessous. Vous pourrez toujours compléter ou modifier le plan plus tard (édition du plan ou import XLSX depuis la fiche).</target>
       </trans-unit>
       <trans-unit id="139t" resname="planSpreadsheet.header.taskPosition">
         <source>planSpreadsheet.header.taskPosition</source>


### PR DESCRIPTION
## Contexte

Ferme **#45**.

## Résumé

- **Import XLSX** : modale enrichie (intro, téléchargement du modèle vierge, avertissement, règles détaillées, fichier). Nouvelle route `GET /plans/import-template` pour le fichier modèle.
- **Création de plan** : les tâches et sous-tâches restent saisissables dans le formulaire, mais sont **facultatives** (filtrage des entrées vides en `PRE_SUBMIT`). Message d’aide déplacé dans la section Tâches.
- **UX formulaire** : suppression de la barre d’actions fixe et du bouton « Aller tout en bas » ; **Enregistrer** dans un `card-footer` en fin de formulaire (création et édition). Nettoyage du CSS associé.
- **Stimulus** (`plan_form_controller`) : placeholder tâches au chargement ; plus de sous-tâche auto à l’ajout d’une tâche.

## Traductions

Mises à jour `messages+intl-icu.fr.xlf` (modale import, `newPlanTasksOptionalHint`, etc.).

## Tests manuels suggérés

1. Créer un plan **sans** tâche → enregistrement OK.
2. Créer un plan **avec** tâches / sous-tâches → OK.
3. Sur la fiche plan (gestionnaire) : ouvrir la modale import, télécharger le modèle, vérifier les textes.
4. Édition d’un plan : pied de carte avec uniquement Enregistrer, pas de bouton fixe.